### PR TITLE
Build the plugin as a function for type: module projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-mock-server",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Vite mock server plugin",
   "main": "dist/index.js",
   "scripts": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "esnext",
-    "module": "commonjs",
+    "module": "esnext",
     "moduleResolution": "node",
     "strict": true,
     "sourceMap": true,


### PR DESCRIPTION
As marked in #22 and in #17 the builded js file needs to be an ES modules. Please merge or build twice with the option to use that file with the "export default" instead of 'exports.default'

![image](https://github.com/enjoycoding/vite-plugin-mock-server/assets/4329883/a60544ff-a83a-4086-ae4a-34b2e46110c9)

 