### PR TITLE
Respect configured log level for startup message

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -70,10 +70,11 @@ export default (options?: MockOptions): Plugin => {
         console.warn('[' + PLUGIN_NAME + '] mock modules will be set automatically, and the configuration will be ignored', options.mockModules)
       }
       options.mockModules = []
-      LOG_LEVEL = options.logLevel
+      const initialLogLevel = LOG_LEVEL = options.logLevel;
       // watch mock files
       watchMockFiles(options).then(() => {
-        console.log('[' + PLUGIN_NAME + '] mock server started. options =', options)
+        if ("info" === initialLogLevel)
+          console.log('[' + PLUGIN_NAME + '] mock server started. options =', options);
       })
       if (options.middlewares) {
         for (const [, layer] of options.middlewares.entries()) {


### PR DESCRIPTION
Quick patch that disables the "mock server started" message if `logLevel` is not set to `"info"`. Feel free to disagree with the implementation, though there should be some option to disable the message. The message could also be more congruent with the Vite logger, but I haven't looked into Vite internals at all and don't know how easy that is.

Thanks for this neat package! Saved me a lot of time ;)