### PR TITLE
Fix default values for falsy options

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -66,8 +66,8 @@ export default (options?: MockOptions): Plugin => {
       options.mockRootDir = options.mockRootDir || './mock'
       options.mockJsSuffix = options.mockJsSuffix || '.mock.js'
       options.mockTsSuffix = options.mockTsSuffix || '.mock.ts'
-      options.noHandlerResponse404 = options.noHandlerResponse404 || true
-      options.printStartupLog = options.printStartupLog || true
+      options.noHandlerResponse404 = ("noHandlerResponse404" in options) ? !!options.noHandlerResponse404 : true;
+      options.printStartupLog = ("printStartupLog" in options) ? !!options.printStartupLog : true;
       if (options.mockModules && options.mockModules.length > 0) {
         console.warn('[' + PLUGIN_NAME + '] mock modules will be set automatically, and the configuration will be ignored', options.mockModules)
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,8 +66,8 @@ export default (options?: MockOptions): Plugin => {
       options.mockRootDir = options.mockRootDir || './mock'
       options.mockJsSuffix = options.mockJsSuffix || '.mock.js'
       options.mockTsSuffix = options.mockTsSuffix || '.mock.ts'
-      options.noHandlerResponse404 = ("noHandlerResponse404" in options) ? !!options.noHandlerResponse404 : true;
-      options.printStartupLog = ("printStartupLog" in options) ? !!options.printStartupLog : true;
+      options.noHandlerResponse404 = (typeof options.noHandlerResponse404 !== "undefined") ? !!options.noHandlerResponse404 : true;
+      options.printStartupLog = (typeof options.printStartupLog !== "undefined") ? !!options.printStartupLog : true;
       if (options.mockModules && options.mockModules.length > 0) {
         console.warn('[' + PLUGIN_NAME + '] mock modules will be set automatically, and the configuration will be ignored', options.mockModules)
       }


### PR DESCRIPTION
As it stands it is impossible to pass a falsy value to certain config keys, namely ``noHandlerResponse404`` and ``printStartupLog``. This is because whether or not the default value is used depends on the truthiness of the supplied value.
```ts
options.noHandlerResponse404 = options.noHandlerResponse404 || true // (boolean | undefined) || true is always true
options.printStartupLog = options.printStartupLog || true // (boolean | undefined) || true is always true
```

I propose that for these keys, the truthiness of the value should be used only if it is explicitly set.
```ts
options.noHandlerResponse404 = ("noHandlerResponse404" in options) ? !!options.noHandlerResponse404 : true;
options.printStartupLog = ("printStartupLog" in options) ? !!options.printStartupLog : true;
```

Examples:
| Supplied | Current | Revision 1 | Revision 2 |
| :-: | :-: | :-: | :-: |
| ``true`` | ``true`` | ``true`` | ``true`` | 
| ``{}`` | ``{}`` | ``true`` | ``true`` |
| ``<unspecified>``* | ``true`` | ``true`` | ``true`` |
| ``false`` | ``true`` | ``false`` | ``false`` |
| ``0`` | ``true`` | ``false`` | ``false`` |
| ``undefined`` | ``true`` | ``false`` | ``true`` | 

<sub>* Key not present in map</sub>